### PR TITLE
Add test image from twitch and fix images having a duration of <= 10ms

### DIFF
--- a/api.py
+++ b/api.py
@@ -54,7 +54,7 @@ def process_gif(gif_path):
     for i in range(0, img.n_frames):
         img.seek(i)
         imgDuration = img.info['duration'];
-        if imgDuration == 0 or imgDuration == 10:
+        if imgDuration <= 10:
             imgDuration = 100
         duration += imgDuration
         frame = numpy.array(img.convert('RGB'))

--- a/api.py
+++ b/api.py
@@ -50,9 +50,13 @@ def process_gif(gif_path):
     duration = 0
     num_flashes = 0
     prev_frame = None
+    print(f"Animated: {img.is_animated}; N-Frames: {img.n_frames}; Duration: {img.info['duration']} (URL: {gif_path})")
     for i in range(0, img.n_frames):
         img.seek(i)
-        duration += img.info['duration']
+        imgDuration = img.info['duration'];
+        if imgDuration == 0 or imgDuration == 10:
+            imgDuration = 100
+        duration += imgDuration
         frame = numpy.array(img.convert('RGB'))
 
         # If not the first frame calculate diff to previous frame

--- a/test_epilepsy.py
+++ b/test_epilepsy.py
@@ -15,7 +15,8 @@ def main():
         ("https://media.tenor.com/IUmIvOuUzMAAAAAd/disco-distracted.gif", True),
         ("https://media.tenor.com/yzwcdxxlnqYAAAAi/hmmm-thinking.gif", False),
         # ("https://static-cdn.jtvnw.net/emoticons/v2/emotesv2_5169f685980a4c11b71f913bbf9d25d6/default/dark/3.0", False),
-        ("https://i.pinimg.com/originals/19/81/9e/19819ebc0065a496ef95a8069ad0dc76.gif", False)
+        ("https://i.pinimg.com/originals/19/81/9e/19819ebc0065a496ef95a8069ad0dc76.gif", False),
+        ("https://static-cdn.jtvnw.net/emoticons/v2/emotesv2_d30b413bc2c04591b2eab8c20bdc7627/default/dark/3.0", True)
     ]
     for i in range(len(images)):
         expected = images[i][1]
@@ -36,7 +37,8 @@ def test_epilepsy_triggering():
         "https://static-cdn.jtvnw.net/emoticons/v2/emotesv2_502bf8fd256b44348d9a5b9c546bee67/default/dark/3.0",
         "https://media.tenor.com/Jt9XZCbBEnkAAAAd/khosalis-snail.gif",
         "https://media.tenor.com/y_v9qSrp4ckAAAAC/moving-art.gif",
-        "https://media.tenor.com/IUmIvOuUzMAAAAAd/disco-distracted.gif"
+        "https://media.tenor.com/IUmIvOuUzMAAAAAd/disco-distracted.gif",
+        "https://static-cdn.jtvnw.net/emoticons/v2/emotesv2_d30b413bc2c04591b2eab8c20bdc7627/default/dark/3.0"
     ]
     for i in range(len(images)):
         assert safegif.process_gif(images[i])


### PR DESCRIPTION
If you want to know where there is a second commit read http://forums.mozillazine.org/viewtopic.php?t=108528 (Had to do that because of a `ZeroDivisionError: division by zero` when its animated, but duration is 0 for each frame.